### PR TITLE
FEAT: Gives the option to send all files in a single request #32

### DIFF
--- a/src/Dropzone/components/dropzone/DropzoneProps.ts
+++ b/src/Dropzone/components/dropzone/DropzoneProps.ts
@@ -99,6 +99,11 @@ export interface DropzoneFullProps extends OverridableComponentProps {
    */
   fakeUpload?: boolean;
   /**
+   * If set, will upload all loaded files in a single multipart request appending array of files
+   * to the FormData files key
+   */
+  groupUpload?: boolean;
+  /**
    * Callback fired when the upload process starts.
    */
   onUploadStart?: (uploadAbleFiles: ExtFile[]) => void;


### PR DESCRIPTION
By setting groupUpload prop all files are sent in a single formData object within an array. #32 